### PR TITLE
Using 16kb page device for testing

### DIFF
--- a/.github/workflows/Unified.yml
+++ b/.github/workflows/Unified.yml
@@ -69,7 +69,7 @@ jobs:
         run: ./gradlew :media-file:assembleRelease
 
       - name: Testing
-        run: ./gradlew :media-file:pixel2api35ReleaseAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect
+        run: ./gradlew :media-file:pixel2api35ReleaseAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect --info
 
       - name: Publishing the library to Maven Central
         # Only for 'When a release is created via Github UI'

--- a/.github/workflows/Unified.yml
+++ b/.github/workflows/Unified.yml
@@ -69,7 +69,7 @@ jobs:
         run: ./gradlew :media-file:assembleRelease
 
       - name: Testing
-        run: ./gradlew :media-file:pixel2api34ReleaseAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect
+        run: ./gradlew :media-file:pixel2api35ReleaseAndroidTest -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect
 
       - name: Publishing the library to Maven Central
         # Only for 'When a release is created via Github UI'

--- a/media-file/build.gradle.kts
+++ b/media-file/build.gradle.kts
@@ -47,10 +47,10 @@ android {
     testOptions {
         managedDevices {
             localDevices {
-                create("pixel2api34") {
+                create("pixel2api35") {
                     device = "Pixel 2"
-                    apiLevel = 34
-                    systemImageSource = "aosp"
+                    apiLevel = 35
+                    systemImageSource = "google_apis_ps16k"
                 }
             }
         }


### PR DESCRIPTION
Using Android 15 device with 16 kb page size for testing.

This particular PR is expected to fail due to the library current incompatibility with Android 15/page size 16 kb. This is done mainly for testing the `google_apis_ps16k` image itself to require the updated native libraries.