### PR TITLE
Android 15 with 16kb page size support

### DIFF
--- a/media-file/build.gradle.kts
+++ b/media-file/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "io.github.javernaut.mediafile"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         minSdk = 21
@@ -18,6 +18,13 @@ android {
 
         ndk {
             abiFilters += listOf("x86", "x86_64", "armeabi-v7a", "arm64-v8a")
+        }
+        externalNativeBuild {
+            cmake {
+                // NDK r27-specific solution for compatibility with 16 kb page
+                // Once migrated to NDK r28, this flag will not be needed
+                arguments += listOf("-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON")
+            }
         }
     }
 

--- a/media-file/build.gradle.kts
+++ b/media-file/build.gradle.kts
@@ -59,6 +59,13 @@ android {
                     apiLevel = 34
                     systemImageSource = "aosp"
                 }
+                // TODO Use this device on CI once the issue is resolved: https://issuetracker.google.com/issues/377321470
+                // For now, local testing is enough to confirm 16 kb pages are implemented properly
+                create("pixel2api35") {
+                    device = "Pixel 2"
+                    apiLevel = 35
+                    systemImageSource = "google_apis_ps16k"
+                }
             }
         }
     }


### PR DESCRIPTION
Updating ffmpeg-andorid-maker to 2.12, which supports generating 16 kb page size friendly shared libraries of FFmpeg.

Generating a similar media-file.so in the NDK r27 way.

Adding a GMD for testing the thing. This GMD can't run properly on Github Actions at the moment due to the [issue](https://issuetracker.google.com/issues/377321470), so sticking to local tests on this one.